### PR TITLE
fix: raise error when multiple versions are passed to global subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ https://galaxy.ansible.com/suzuki-shunsuke/pyenv-module/
 
 ## Notice
 
-* This module doesn't support the check mode
+* This module doesn't support the [check mode](http://docs.ansible.com/ansible/dev_guide/developing_modules_general.html#supporting-check-mode)
 
 ## Supported platform
 

--- a/library/pyenv.py
+++ b/library/pyenv.py
@@ -206,7 +206,7 @@ def cmd_set_global(module, cmd_path, versions, **kwargs):
             versions=versions, changed=False, stdout="", stderr="")
         return None
     rc, out, err = module.run_command(
-        [cmd_path, "global", " ".join(versions)], **kwargs)
+        [cmd_path, "global"] + versions, **kwargs)
     if rc:
         module.fail_json(msg=err, stdout=out)
     else:

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -39,11 +39,19 @@
     register: result
   - debug:
       var: result
-  - name: pyenv global 3.6.1
+  - name: pyenv install -s 2.7.13
+    pyenv:
+      version: 2.7.13
+      pyenv_root: "{{pyenv_root}}"
+    register: result
+  - debug:
+      var: result
+  - name: pyenv global 3.6.1 2.7.13
     pyenv:
       subcommand: global
       versions:
       - 3.6.1
+      - 2.7.13
       pyenv_root: "{{pyenv_root}}"
     register: result
   - debug:
@@ -54,13 +62,6 @@
       pyenv_root: "{{pyenv_root}}"
     register: result
     failed_when: result.changed
-  - debug:
-      var: result
-  - name: pyenv install -s 2.7.13
-    pyenv:
-      version: 2.7.13
-      pyenv_root: "{{pyenv_root}}"
-    register: result
   - debug:
       var: result
   - name: pyenv global 2.7.13


### PR DESCRIPTION
```
- name: pyenv global 3.6.1 2.7.13
  pyenv:
    subcommand: global
    versions:
    - 3.6.1
    - 2.7.13
```

```
TASK [pyenv global 3.6.1 2.7.13] ***********************************************
fatal: [ubuntu]: FAILED! => {"changed": false, "failed": true, "msg": "pyenv: version `3.6.1 2.7.13' not installed\n", "stdout": "
", "stdout_lines": []}
```